### PR TITLE
Use `|` as separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = {
           errors = "";
         }
 
-        return project.generateTestFile('JSHint - ' + relativePath, [{
+        return project.generateTestFile('JSHint | ' + relativePath, [{
           name: 'should pass jshint',
           passed: !!passed,
           errorMessage: relativePath + ' should pass jshint.' + errors


### PR DESCRIPTION
Ember uses `|` to separate the type of test from the actual test. e.g.

`Acceptance | Login page: lorem ipsum`.

This PR changes the jshint auto generated tests names to something like

`JSHint | app/routes/application.js: should pass jshint`
