### PR TITLE
Update `broccoli-jshint` and explicitly set `targetExtension`

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = {
 
   init: function() {
     this._super.init && this._super.init.apply(this, arguments);
-    
+
     this.buildConsole();
   },
 
@@ -44,6 +44,7 @@ module.exports = {
 
     return require('broccoli-jshint')(tree, {
       jshintrcPath: this.jshintrc[type],
+      targetExtension: 'jshint.lint-test.js',
       description: 'JSHint ' +  type,
       console: this.console,
       testGenerator: function(relativePath, passed, errors) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "broccoli-jshint": "^1.0.0"
+    "broccoli-jshint": "^2.1.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
see https://github.com/rwjblue/broccoli-jshint/pull/48

this can be considered a breaking change so we should probably require a major version bump here, right?

/cc @rwjblue @mitchlloyd 
