### PR TITLE
Expose failOnAnyError option

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = {
       targetExtension: 'jshint.lint-test.js',
       description: 'JSHint ' +  type,
       console: this.console,
+      failOnAnyError: this.jshintrc.failOnAnyError,
       testGenerator: function(relativePath, passed, errors) {
         if (errors) {
           errors = "\\n" + this.escapeErrorString(errors);


### PR DESCRIPTION
We are using ember@2.10.0 which default linter is `ember-cli-jshint`, however I want it abort the build if any error happens.